### PR TITLE
Improve auth handling and health-check flexibility

### DIFF
--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -18,3 +18,4 @@ OIDC_ISSUER=https://test.example.com
 OIDC_AUDIENCE=test-audience
 OIDC_JWKS_URI=https://test.example.com/.well-known/jwks.json
 SERVICE_VERSION=1.0.0
+ENABLE_DEPENDENCY_HEALTHCHECKS=false

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=production node dist/index.js",
     "dev": "ts-node --project tsconfig.json src/index.ts",
     "lint": "eslint --ext .ts src",
-    "test": "cp .env.test .env && node --test \"dist/**/*.test.js\"",
+    "test": "cp .env.test .env && node --test dist",
     "migrate": "node-pg-migrate up",
     "migrate:down": "node-pg-migrate down"
   },

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -24,7 +24,8 @@ const envSchema = z.object({
   OIDC_ISSUER: z.string(),
   OIDC_AUDIENCE: z.string(),
   OIDC_JWKS_URI: z.string(),
-  SERVICE_VERSION: z.string().default('1.0.0')
+  SERVICE_VERSION: z.string().default('1.0.0'),
+  ENABLE_DEPENDENCY_HEALTHCHECKS: z.enum(['true', 'false']).default('true')
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/apps/api/src/integration.test.ts
+++ b/apps/api/src/integration.test.ts
@@ -1,71 +1,146 @@
-import { test, describe } from 'node:test';
-import assert from 'node:assert';
-import { buildServer } from './server.js';
-import type { FastifyInstance } from 'fastify';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildServer, type BuildServerOptions } from './server.js';
+import type { AuthContext } from './lib/oidc.js';
+import type { TaskPayload } from './routes/tasks.js';
 
-describe('Integration Tests - Phase 0 & Phase 1', () => {
-  test('should create server instance with all routes', async () => {
-    // Test Phase 0 foundation: server builds without errors
-    let app: FastifyInstance | undefined;
-    assert.doesNotThrow(() => {
-      app = buildServer();
-    }, 'Server should build without throwing errors');
+const sampleTask: TaskPayload = {
+  taskId: '123e4567-e89b-12d3-a456-426614174000',
+  agent: 'planner',
+  payload: { example: 'payload' },
+  priority: 5
+};
 
-    assert.ok(app, 'Server instance should be created');
-    
-    // Test that server has required decorations and hooks
-    assert.ok(app.hasDecorator, 'Server should have decorator support');
+const authorizedContext: AuthContext = {
+  subject: 'tester',
+  scope: 'tasks:write',
+  claims: { sub: 'tester' }
+};
+
+function createServer(options: Partial<BuildServerOptions> = {}) {
+  const mergedOptions: BuildServerOptions = {
+    enqueueTask: async () => undefined,
+    enableDependencyHealthChecks: false,
+    verifyAccessToken: async () => authorizedContext,
+    skipResourceShutdown: true,
+    ...options
+  };
+  const app = buildServer(mergedOptions);
+  return app;
+}
+
+test('returns RFC 9457 problem when bearer token is missing', async (t) => {
+  const app = createServer();
+  t.after(async () => {
+    await app.close();
   });
 
-  test('should validate workflow schema structure (Phase 1)', async () => {
-    // Test Phase 1: Workflow request validation
-    const validWorkflowPayload = {
-      workflowType: 'test-workflow',
-      payload: { test: 'data' },
-      metadata: { requestId: '123' }
-    };
-
-    // Test that the workflow payload structure is valid
-    assert.ok(validWorkflowPayload.workflowType, 'Workflow type should be required');
-    assert.ok(validWorkflowPayload.payload, 'Payload should be required');
-    assert.equal(typeof validWorkflowPayload.payload, 'object', 'Payload should be an object');
-    assert.equal(typeof validWorkflowPayload.metadata, 'object', 'Metadata should be an object');
+  const response = await app.inject({
+    method: 'POST',
+    url: '/tasks',
+    payload: sampleTask
   });
 
-  test('should validate task schema structure (Phase 0)', () => {
-    // Test Phase 0: Task request validation
-    const validTaskPayload = {
-      taskId: '123e4567-e89b-12d3-a456-426614174000',
-      agent: 'planner',
-      payload: { test: 'data' },
-      priority: 5
-    };
+  assert.equal(response.statusCode, 401);
+  const body = response.json();
+  assert.equal(body.status, 401);
+  assert.equal(body.title, 'Missing bearer token');
+  assert.equal(body.type, 'about:blank');
+});
 
-    // Test that the task payload structure is valid
-    assert.ok(validTaskPayload.taskId, 'Task ID should be required');
-    assert.ok(validTaskPayload.agent, 'Agent should be required');
-    assert.ok(['planner', 'coder', 'critic'].includes(validTaskPayload.agent), 'Agent should be valid enum');
-    assert.equal(typeof validTaskPayload.payload, 'object', 'Payload should be an object');
-    assert.equal(typeof validTaskPayload.priority, 'number', 'Priority should be a number');
+test('returns RFC 9457 problem when bearer token verification fails', async (t) => {
+  let verifyAttempts = 0;
+  const app = createServer({
+    verifyAccessToken: async () => {
+      verifyAttempts += 1;
+      throw new Error('invalid token');
+    }
+  });
+  t.after(async () => {
+    await app.close();
   });
 
-  test('should validate database schemas exist (Phase 0)', async () => {
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    
-    // Test that database migrations exist
-    const migrationsPath = path.resolve('migrations');
-    assert.ok(fs.existsSync(path.join(migrationsPath, '001_init.sql')), 'Initial migration should exist');
-    assert.ok(fs.existsSync(path.join(migrationsPath, '002_event_sourcing.sql')), 'Event sourcing migration should exist');
+  const response = await app.inject({
+    method: 'POST',
+    url: '/tasks',
+    payload: sampleTask,
+    headers: {
+      authorization: 'Bearer invalid'
+    }
   });
 
-  test('should validate Phase 1 core modules exist', async () => {
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    
-    // Test that Phase 1 implementations exist
-    const srcPath = path.resolve('src/lib');
-    assert.ok(fs.existsSync(path.join(srcPath, 'event-store.ts')), 'Event Store should exist');
-    assert.ok(fs.existsSync(path.join(srcPath, 'saga-orchestrator.ts')), 'Saga Orchestrator should exist');
+  assert.equal(verifyAttempts, 1);
+  assert.equal(response.statusCode, 401);
+  const body = response.json();
+  assert.equal(body.status, 401);
+  assert.equal(body.title, 'Invalid bearer token');
+  assert.equal(body.type, 'about:blank');
+});
+
+test('readiness succeeds without invoking dependency checks when disabled', async (t) => {
+  let dependencyChecks = 0;
+  const app = createServer({
+    dependencyHealthCheck: async () => {
+      dependencyChecks += 1;
+    },
+    enableDependencyHealthChecks: false
   });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/health/ready'
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json();
+  assert.equal(body.status, 'ok');
+  assert.equal(dependencyChecks, 0);
+});
+
+test('readiness executes dependency checks when enabled', async (t) => {
+  let dependencyChecks = 0;
+  const app = createServer({
+    dependencyHealthCheck: async () => {
+      dependencyChecks += 1;
+    },
+    enableDependencyHealthChecks: true
+  });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/health/ready'
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(dependencyChecks, 1);
+});
+
+test('authorized task submission enqueues payload', async (t) => {
+  const enqueued: TaskPayload[] = [];
+  const app = createServer({
+    enqueueTask: async (payload) => {
+      enqueued.push(payload);
+    }
+  });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/tasks',
+    payload: sampleTask,
+    headers: {
+      authorization: 'Bearer valid'
+    }
+  });
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(enqueued, [sampleTask]);
 });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -17,16 +17,7 @@ interface TaskDependencies {
 export function registerTaskRoutes(app: FastifyInstance, deps: TaskDependencies): void {
   app.post('/tasks', {
     schema: {
-      body: {
-        type: 'object',
-        required: ['taskId', 'agent', 'payload'],
-        properties: {
-          taskId: { type: 'string', format: 'uuid' },
-          agent: { type: 'string', enum: ['planner', 'coder', 'critic'] },
-          payload: { type: 'object' },
-          priority: { type: 'integer', minimum: 0, maximum: 10, default: 5 }
-        }
-      }
+      body: taskSchema
     }
   }, async (request, reply) => {
     const body = taskSchema.parse(request.body);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,4 +1,4 @@
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyError } from 'fastify';
 import fastifyHelmet from '@fastify/helmet';
 import fastifyRateLimit from '@fastify/rate-limit';
 import fastifySensible from '@fastify/sensible';
@@ -8,12 +8,25 @@ import { problemErrorHandler } from './lib/problem.js';
 import { verifyPostgres, postgresPool } from './lib/postgres.js';
 import { redisClient, verifyRedis } from './lib/redis.js';
 import { kafka, verifyKafka } from './lib/kafka.js';
-import { verifyAccessToken } from './lib/oidc.js';
+import { verifyAccessToken, type AuthContext } from './lib/oidc.js';
 import { registerHealthRoutes } from './routes/health.js';
 import { registerTaskRoutes, type TaskPayload } from './routes/tasks.js';
 import workflowRoutes from './routes/workflow.js';
 
-export function buildServer(): FastifyInstance {
+export interface BuildServerOptions {
+  verifyAccessToken?: (token: string) => Promise<AuthContext>;
+  dependencyHealthCheck?: () => Promise<void>;
+  enableDependencyHealthChecks?: boolean;
+  enqueueTask?: (payload: TaskPayload) => Promise<void>;
+  skipResourceShutdown?: boolean;
+}
+
+function hasStatusCode(error: unknown): error is FastifyError {
+  return typeof error === 'object' && error !== null && 'statusCode' in error &&
+    typeof (error as Partial<FastifyError>).statusCode === 'number';
+}
+
+export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
   const app = Fastify({
     trustProxy: true,
     logger: {
@@ -37,50 +50,75 @@ export function buildServer(): FastifyInstance {
 
   app.decorateRequest('auth', null);
 
-  app.addHook('onRequest', async (request, reply) => {
-    if (request.routerPath?.startsWith('/health')) {
+  const verifyToken = options.verifyAccessToken ?? verifyAccessToken;
+  const dependencyHealthCheck = options.dependencyHealthCheck ?? (async () => {
+    await Promise.all([verifyPostgres(), verifyRedis(), verifyKafka()]);
+  });
+  const shouldCheckDependencies = options.enableDependencyHealthChecks ?? (env.ENABLE_DEPENDENCY_HEALTHCHECKS === 'true');
+
+  app.addHook('onRequest', async (request) => {
+    const routeUrl = request.routeOptions?.url;
+    if (routeUrl?.startsWith('/health')) {
       request.auth = null;
       return;
     }
 
     const authHeader = request.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
-      reply.code(401);
-      throw new Error('Missing bearer token');
+      throw app.httpErrors.unauthorized('Missing bearer token');
     }
     const token = authHeader.slice('Bearer '.length);
-    request.auth = await verifyAccessToken(token);
+    try {
+      request.auth = await verifyToken(token);
+    } catch (error) {
+      request.auth = null;
+      if (hasStatusCode(error)) {
+        throw error;
+      }
+      request.log.warn({ err: error }, 'Failed to verify access token');
+      throw app.httpErrors.unauthorized('Invalid bearer token');
+    }
   });
 
   app.setErrorHandler(problemErrorHandler);
 
   registerHealthRoutes(app, {
     async check() {
-      await Promise.all([verifyPostgres(), verifyRedis(), verifyKafka()]);
+      if (!shouldCheckDependencies) {
+        return;
+      }
+      await dependencyHealthCheck();
     }
   });
-  const producer = kafka.producer();
-  let producerReady = false;
-  let producerConnectPromise: Promise<void> | null = null;
 
-  async function ensureProducer(): Promise<void> {
-    if (producerReady) {
-      return;
-    }
-    if (!producerConnectPromise) {
-      producerConnectPromise = producer.connect()
-        .then(() => {
-          producerReady = true;
-        })
-        .finally(() => {
-          producerConnectPromise = null;
-        });
-    }
-    await producerConnectPromise;
-  }
+  let closeTaskResources: (() => Promise<void>) | null = null;
+  let enqueueTask: (payload: TaskPayload) => Promise<void>;
+  const skipResourceShutdown = options.skipResourceShutdown ?? false;
 
-  registerTaskRoutes(app, {
-    async enqueueTask(payload: TaskPayload) {
+  if (options.enqueueTask) {
+    enqueueTask = options.enqueueTask;
+  } else {
+    const producer = kafka.producer();
+    let producerReady = false;
+    let producerConnectPromise: Promise<void> | null = null;
+
+    const ensureProducer = async (): Promise<void> => {
+      if (producerReady) {
+        return;
+      }
+      if (!producerConnectPromise) {
+        producerConnectPromise = producer.connect()
+          .then(() => {
+            producerReady = true;
+          })
+          .finally(() => {
+            producerConnectPromise = null;
+          });
+      }
+      await producerConnectPromise;
+    };
+
+    enqueueTask = async (payload: TaskPayload) => {
       await ensureProducer();
       await producer.send({
         topic: 'agent.tasks',
@@ -89,20 +127,35 @@ export function buildServer(): FastifyInstance {
           value: JSON.stringify(payload)
         }]
       });
+    };
+
+    closeTaskResources = async () => {
+      await producer.disconnect().then(() => {
+        producerReady = false;
+      }).catch(() => undefined);
+    };
+  }
+
+  registerTaskRoutes(app, {
+    async enqueueTask(payload: TaskPayload) {
+      await enqueueTask(payload);
     }
   });
 
   void app.register(workflowRoutes);
 
   app.addHook('onClose', async () => {
-    await Promise.all([
-      postgresPool.end(),
-      redisClient.quit(),
-      producer.disconnect().then(() => {
-        producerReady = false;
-      }).catch(() => undefined)
-    ]);
+    const shutdownTasks: Array<Promise<unknown>> = [];
+    if (!skipResourceShutdown) {
+      shutdownTasks.push(postgresPool.end());
+      shutdownTasks.push(redisClient.quit().catch(() => undefined));
+    }
+    if (closeTaskResources) {
+      shutdownTasks.push(closeTaskResources().catch(() => undefined));
+    }
+    await Promise.all(shutdownTasks);
   });
 
   return app as FastifyInstance;
 }
+


### PR DESCRIPTION
## Summary
- refine the Fastify authentication hook to emit typed HTTP errors and allow dependency injection for testing
- add optional dependency health-check toggles and resource shutdown controls to simplify readiness verification in constrained environments
- update task route validation to use Zod schemas and extend integration coverage for auth and readiness flows

## Testing
- npm run lint --workspace=apps/api
- npm run build
- npm run test --workspace=apps/api

------
https://chatgpt.com/codex/tasks/task_e_68cf19bc4bf8832a88dea8a1e244bae7